### PR TITLE
fix: update SDK Versions for android and ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.18
+* Updated HyperSDK version for iOS to 2.1.43 and for Android, 2.1.32.
+* Added HyperSDK Override support for IOS.
+
 # 4.0.17
 * Removing activity from process call.
 * Added support to exclude microSdks.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ buildscript {
     ext {
         ....
         clientId = "<clientId shared by Juspay team>"
-        hyperSDKVersion = "2.1.25"
+        hyperSDKVersion = "2.1.32"
         excludedMicroSDKs = []
         ....
     }
@@ -67,6 +67,20 @@ Create file `ios/MerchantConfig.txt` with the following content
 
 ```txt
 clientId = <clientId> shared by Juspay Team
+```
+
+Optional : (Optional) Add the following variable in [pubspec.yaml](https://github.com/juspay/hyper-sdk-flutter/blob/main/example/pubspec.yaml) of your project before running pod install if you want to override the base SDK version present in the plugin (the newer version among both would be considered):
+
+In your `pubspec.yaml` file:
+
+```yaml
+# pubspec.yaml
+name: your_flutter_app
+description: A new Flutter project.
+
+# Other configurations...
+
+hyper_sdk_ios_version: "<New version>"
 ```
 
 ## Usage

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext {
         clientId = "geddit"
-        hyperSDKVersion = "2.1.25"
+        hyperSDKVersion = "2.1.32"
         excludedMicroSDKs = []
     }
 

--- a/example/ios/MerchantConfig.txt
+++ b/example/ios/MerchantConfig.txt
@@ -1,1 +1,1 @@
-clientId = A23Games
+clientId = geddit

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,12 +7,12 @@ PODS:
   - flutter_inappwebview_ios/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 5.0)
-  - HyperSDK (2.1.40.1):
+  - HyperSDK (2.1.43):
     - JuspaySafeBrowser (= 0.1.83)
     - Salvator (= 1.0.6)
   - hypersdkflutter (4.0.17):
     - Flutter
-    - HyperSDK (= 2.1.40.1)
+    - HyperSDK (= 2.1.43)
   - JuspaySafeBrowser (0.1.83)
   - OrderedSet (5.0.0)
   - Salvator (1.0.6)
@@ -40,12 +40,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_inappwebview_ios: 97215cf7d4677db55df76782dbd2930c5e1c1ea0
-  HyperSDK: 0152839cab1ea2889402c892bebc6fd09cbfc7aa
-  hypersdkflutter: 1a43f98d6febba6417bf3f366c22c320baf6e8bc
+  HyperSDK: fdcd5a244b85e296d02f3b13057015ef2a66e3f8
+  hypersdkflutter: cf51bb343a5a53da7c4c08979d20eb5cfc79cd22
   JuspaySafeBrowser: 91be796164a40317d5a9153ac6d433a4928ef549
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   Salvator: 1de69620ac17123ba3491e27a9a8b35bc5b97eaa
 
 PODFILE CHECKSUM: cba9212f3b66a15bdfc427a805562f0aba11c0e6
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -49,6 +49,7 @@
 		<string>slice-upi</string>
 		<string>ppe</string>
 		<string>cugext</string>
+		<string>amazonpay</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,6 +17,9 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
+# Overriding IOS HyperSDK Version for Juspay SDK.
+hyper_sdk_ios_version: "2.1.43"
+
 environment:
   sdk: ">=2.17.0 <4.0.0"
 

--- a/ios/hypersdkflutter.podspec
+++ b/ios/hypersdkflutter.podspec
@@ -1,7 +1,26 @@
-#
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint hypersdk.podspec` to validate before publishing.
-#
+require "yaml"
+
+hyper_sdk_version = "2.1.43"
+
+begin
+  # Read hyper_sdk_version from pubspec.yaml if it exists
+  pubspec_path = File.expand_path(File.join(__dir__, "../../../../../pubspec.yaml"))
+  if File.exist?(pubspec_path)
+    pubspec = YAML.load_file(pubspec_path)
+    if pubspec["hyper_sdk_ios_version"]
+      override_version = pubspec["hyper_sdk_ios_version"]
+      hyper_sdk_version = Gem::Version.new(override_version) > Gem::Version.new(hyper_sdk_version) ? override_version : hyper_sdk_version
+      if hyper_sdk_version != override_version
+        puts ("Ignoring the overridden SDK version present in pubspec.yaml (#{override_version}) as there is a newer version present in the SDK (#{hyper_sdk_version}).").yellow
+      end
+    end
+  end
+rescue => e
+  puts ("An error occurred while overriding the IOS SDK Version. #{e.message}").red
+end
+
+puts ("HyperSDK HyperSDK Version Version: #{hyper_sdk_version}")
+
 Pod::Spec.new do |s|
   s.name             = 'hypersdkflutter'
   s.version          = '4.0.17'
@@ -15,10 +34,10 @@ Flutter plugin for juspay SDK.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'HyperSDK', '2.1.40.1'
+  s.dependency 'HyperSDK', hyper_sdk_version
   s.platform = :ios, '12.0'
 
-  # Flutter.framework does not contain a i386 slice.
+  # Flutter.framework does not contain an i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
* Updated HyperSDK version for iOS to 2.1.43 and for Android, 2.1.32.
- **Added HyperSDK Override Support for iOS**
  - Clients can now override the `HyperSDK` version for iOS with a newer version if the newer version is not updated in the package.
  - To use this feature, add the `hyper_sdk_ios_version` entry in your `pubspec.yaml` file with the desired version.

#### Example:

In your `pubspec.yaml` file:

```yaml
# pubspec.yaml
name: your_flutter_app
description: A new Flutter project.

# Other configurations...

hyper_sdk_ios_version: "<New version>"