### PR TITLE
Removed EXCLUDED_ARCHS config from podspec

### DIFF
--- a/ios/hypersdkflutter.podspec
+++ b/ios/hypersdkflutter.podspec
@@ -37,8 +37,4 @@ Flutter plugin for juspay SDK.
   s.dependency 'HyperSDK', hyper_sdk_version
   s.platform = :ios, '12.0'
   s.swift_version = "5.0"
-
-  # Flutter.framework does not contain an i386 slice.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
These exclusions were legacy workarounds for 32-bit simulators (i386) and Apple Silicon simulator build issues (arm64) that are no longer required on Xcode 14+.