### PR TITLE
fix: QR-6714: added activity context in Process

### DIFF
--- a/android/src/main/kotlin/in/juspay/hyper_sdk_flutter/HyperSdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/in/juspay/hyper_sdk_flutter/HyperSdkFlutterPlugin.kt
@@ -271,7 +271,14 @@ class HyperSdkFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
             return
         }
         webViewConfigurationCallback?.let { hyperServices.setWebViewConfigurationCallback(it) }
-        hyperServices.process(JSONObject(params))
+        
+        val activity = binding?.activity
+            ?: return result.success(false)
+        if (activity !is FragmentActivity) {
+            throw Exception("Kotlin MainActivity should extend FlutterFragmentActivity instead of FlutterActivity!")
+        }
+        
+        hyperServices.process(activity,JSONObject(params))
         result.success(true)
     }
 


### PR DESCRIPTION
Flutter fragment view id not updating after app is brought from the background.