### PR TITLE
fix: replace print with debugPrint

### DIFF
--- a/example/lib/screens/checkout.dart
+++ b/example/lib/screens/checkout.dart
@@ -258,7 +258,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
               if (_payloadController.text.trim().isNotEmpty) {
                 try {
                   customPayload = json.decode(_payloadController.text.trim());
-                  print('Using custom payload: $customPayload');
+                  debugPrint('Using custom payload: $customPayload');
                 } catch (e) {
                   // Show error dialog for invalid JSON
                   showDialog(
@@ -284,7 +284,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                 context,
                 MaterialPageRoute(builder: (context) {
                   if (useContainer) {
-                    print('HH useContainer - true');
+                    debugPrint('HH useContainer - true');
                     return ContainerPaymentPage(
                         hyperSDK: widget.hyperSDK,
                         amount: amounts['totalAmount'].toString(),
@@ -292,7 +292,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                         customerDetails: widget.customerDetails,
                         customPayload: customPayload);
                   } else {
-                    print('HH useContainer - false');
+                    debugPrint('HH useContainer - false');
                     return PaymentPage(
                         hyperSDK: widget.hyperSDK,
                         amount: amounts['totalAmount'].toString(),

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -139,9 +139,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
   void initiateCallbackHandler(MethodCall methodCall) {
     if (methodCall.method == "initiate_result") {
-      print("Debug initiate_result " + methodCall.arguments);
+      debugPrint("Debug initiate_result " + methodCall.arguments);
     } else if (methodCall.method == "process_result") {
-      print("Debug process_result " + methodCall.arguments);
+      debugPrint("Debug process_result " + methodCall.arguments);
     }
   }
 

--- a/example/lib/screens/payment_page.dart
+++ b/example/lib/screens/payment_page.dart
@@ -84,14 +84,14 @@ class _PaymentPageState extends State<PaymentPage> {
     // Check if custom payload is provided
     if (widget.customPayload != null) {
       processPayload = widget.customPayload!;
-      print('Using custom payload: $processPayload');
+      debugPrint('Using custom payload: $processPayload');
     } else {
       // Get process payload from backend
       // block:start:fetch-process-payload
       processPayload = await getProcessPayload(
           widget.amount, widget.merchantDetails, widget.customerDetails);
       // block:end:fetch-process-payload
-      print('Using auto-generated payload: $processPayload');
+      debugPrint('Using auto-generated payload: $processPayload');
     }
 
     // Calling process on hyperSDK to open payment page
@@ -125,7 +125,7 @@ class _PaymentPageState extends State<PaymentPage> {
         try {
           args = json.decode(methodCall.arguments);
         } catch (e) {
-          print(e);
+          debugPrint(e.toString());
         }
 
         var error = args["error"] ?? false;
@@ -135,7 +135,7 @@ class _PaymentPageState extends State<PaymentPage> {
         var status = innerPayload["status"] ?? " ";
         var pi = innerPayload["paymentInstrument"] ?? " ";
         var pig = innerPayload["paymentInstrumentGroup"] ?? " ";
-        print("$pi, $pig");
+        debugPrint("$pi, $pig");
 
         if (!error) {
           switch (status) {
@@ -160,7 +160,7 @@ class _PaymentPageState extends State<PaymentPage> {
         } else {
           var errorCode = args["errorCode"] ?? " ";
           var errorMessage = args["errorMessage"] ?? " ";
-          print("$errorCode, $errorMessage");
+          debugPrint("$errorCode, $errorMessage");
           switch (status) {
             case "backpressed":
               {

--- a/example/lib/screens/payment_page_container.dart
+++ b/example/lib/screens/payment_page_container.dart
@@ -55,11 +55,11 @@ class _ContainerPaymentPageState extends State<ContainerPaymentPage> {
     Future<Map<String, dynamic>> processPayload;
     if (widget.customPayload != null) {
       processPayload = Future.value(widget.customPayload!);
-      print('Using custom payload in container: ${widget.customPayload}');
+      debugPrint('Using custom payload in container: ${widget.customPayload}');
     } else {
       processPayload = getProcessPayload(
           widget.amount, widget.merchantDetails, widget.customerDetails);
-      print('Using auto-generated payload in container');
+      debugPrint('Using auto-generated payload in container');
     }
 
     // Overriding onBackPressed to handle hardware backpress
@@ -126,7 +126,7 @@ class _ContainerPaymentPageState extends State<ContainerPaymentPage> {
 
     // Calling process on hyperSDK to open payment page
     // block:start:process-sdk
-    print('The process payload $processPayload');
+    debugPrint('The process payload $processPayload');
     await widget.hyperSDK.process(processPayload, hyperSDKCallbackHandler);
     //block:end:process-sdk
   }
@@ -158,11 +158,11 @@ class _ContainerPaymentPageState extends State<ContainerPaymentPage> {
             _showBottomSheetForUpdateOrder(context);
           }
         } catch (e) {
-          print(e);
+          debugPrint(e.toString());
         }
         break;
       case "paymentAttempt":
-        print("Calling _showBottomSheetForUpdateOrder ");
+        debugPrint("Calling _showBottomSheetForUpdateOrder ");
         _showBottomSheetForUpdateOrder(context);
         break;
       case "process_result":
@@ -171,7 +171,7 @@ class _ContainerPaymentPageState extends State<ContainerPaymentPage> {
         try {
           args = json.decode(methodCall.arguments);
         } catch (e) {
-          print(e);
+          debugPrint(e.toString());
         }
 
         var error = args["error"] ?? false;
@@ -181,7 +181,7 @@ class _ContainerPaymentPageState extends State<ContainerPaymentPage> {
         var status = innerPayload["status"] ?? " ";
         var pi = innerPayload["paymentInstrument"] ?? " ";
         var pig = innerPayload["paymentInstrumentGroup"] ?? " ";
-        print("$pi, $pig");
+        debugPrint("$pi, $pig");
 
         if (!error) {
           switch (status) {
@@ -206,7 +206,7 @@ class _ContainerPaymentPageState extends State<ContainerPaymentPage> {
         } else {
           var errorCode = args["errorCode"] ?? " ";
           var errorMessage = args["errorMessage"] ?? " ";
-          print("$errorCode, $errorMessage");
+          debugPrint("$errorCode, $errorMessage");
 
           switch (status) {
             case "backpressed":
@@ -399,7 +399,7 @@ class _BottomSheetContentState extends State<BottomSheetContent> {
                 widget.customerDetails,
                 _newAmount,
               );
-              print("Called updated order");
+              debugPrint("Called updated order");
               widget.hyperSDK.process(updateOrderPayload, widget.callback);
               Navigator.of(context).pop();
               _resetState(); // Reset the state here

--- a/example/lib/utils/generate_payload.dart
+++ b/example/lib/utils/generate_payload.dart
@@ -7,6 +7,7 @@
 
 import 'dart:convert';
 import 'dart:math';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 
@@ -69,7 +70,7 @@ Future<String> signPayload(String payload, String privateKey) async {
   final response = await http.get(url);
 
   if (response.statusCode == 200) {
-    print('The encrypted signature : ${utf8.decode(response.bodyBytes)}');
+    debugPrint('The encrypted signature : ${utf8.decode(response.bodyBytes)}');
     return utf8.decode(response.bodyBytes);
   } else {
     throw Exception('Failed to sign payload: ${response.reasonPhrase}');
@@ -84,7 +85,7 @@ String getOrderId() {
   for (var i = 0; i < 10; i++) {
     result += characters[(Random().nextDouble() * charactersLength).floor()];
   }
-  print('The order id $result');
+  debugPrint('The order id $result');
   return result;
 }
 

--- a/lib/hypersdkflutter.dart
+++ b/lib/hypersdkflutter.dart
@@ -137,7 +137,7 @@ class HyperSDK {
             onPlatformViewCreated: (id) async {
               var viewChannel = MethodChannel('hyper_view_$id');
               Future<dynamic> viewIdCallback(MethodCall methodCall) async {
-                print(
+                debugPrint(
                     'Method Channel triggered for platform view ${methodCall.method}, ${methodCall.arguments}');
                 if (methodCall.method == 'hyperViewCreated') {
                   var viewId = methodCall.arguments as int;


### PR DESCRIPTION
print statements should not be used in production Flutter code as they are not stripped in release builds. This PR replaces all print calls with debugPrint, which is the Flutter-recommended approach as it is automatically suppressed in release mode.

Changes:

Replaced all print calls with debugPrint across the example app and the core plugin
Fixed debugPrint(e) calls in catch blocks to use e.toString() since debugPrint expects a String?
Added missing flutter/foundation.dart import in generate_payload.dart
