### PR TITLE
fix: remove unnecessary Container wrapper

### DIFF
--- a/example/lib/screens/payment_page_container.dart
+++ b/example/lib/screens/payment_page_container.dart
@@ -87,25 +87,21 @@ class _ContainerPaymentPageState extends State<ContainerPaymentPage> {
             child: Center(
                 child: showLoader
                     ? const CircularProgressIndicator()
-                    : Container(
-                        // color: Colors.deepPurple,
-                        // padding: const EdgeInsets.all(20.0),
-                        child: FutureBuilder(
-                            future: processPayload,
-                            builder: (BuildContext context,
-                                AsyncSnapshot<Map<String, dynamic>> snapshot) {
-                              if (snapshot.hasData) {
-                                var processPayload = snapshot.requireData;
-                                var payload = processPayload["payload"];
-                                var orderDetails = payload["orderDetails"];
-                                orderId = jsonDecode(orderDetails)["order_id"];
-                                return widget.hyperSDK.hyperSdkView(
-                                    processPayload, hyperSDKCallbackHandler);
-                              } else {
-                                return const CircularProgressIndicator();
-                              }
-                            }),
-                      )),
+                    : FutureBuilder(
+                        future: processPayload,
+                        builder: (BuildContext context,
+                            AsyncSnapshot<Map<String, dynamic>> snapshot) {
+                          if (snapshot.hasData) {
+                            var processPayload = snapshot.requireData;
+                            var payload = processPayload["payload"];
+                            var orderDetails = payload["orderDetails"];
+                            orderId = jsonDecode(orderDetails)["order_id"];
+                            return widget.hyperSDK.hyperSdkView(
+                                processPayload, hyperSDKCallbackHandler);
+                          } else {
+                            return const CircularProgressIndicator();
+                          }
+                        })),
           ),
         ]),
       ),


### PR DESCRIPTION
Removed a Container widget in payment_page_container.dart that had no properties set (no color, padding, size, or decoration) and was only wrapping a FutureBuilder. This violates the avoid_unnecessary_containers lint rule and adds an extra widget to the tree for no reason.